### PR TITLE
Revert "Make the Docker images produced support `arm64`"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,6 @@ jobs:
         with:
           context: ./
           file: Dockerfile
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ github.repository }}:latest


### PR DESCRIPTION
Reverts geerlingguy/docker-fedora40-ansible#1

Unfortunately the build hangs like it does on other distros right now, not sure why. It's hanging after:

```
#16 307.4 Last metadata expiration check: 0:00:09 ago on Fri Apr 26 21:16:53 2024.
```